### PR TITLE
enable statusBarVisibility

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,9 @@
         "-DLLVM_MOS_PLATFORM=rp6502"
     ],
     "cmake.options.advanced": {
+        "launchTarget": {
+            "statusBarVisibility": "visible"
+        },
         "launch": {
             "statusBarVisibility": "hidden"
         },


### PR DESCRIPTION
Your F5 might not be working because you have to pick a target when you have multiple cmake targets. This will stick a reminder in your status bar.